### PR TITLE
Enable drag & drop for itinerary timeline

### DIFF
--- a/src/app/planner/page.tsx
+++ b/src/app/planner/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import React, { useState, useEffect, useRef } from "react";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
 import ItineraryMap from "@/components/ItineraryMap";
 import ItineraryTimeline from "@/components/ItineraryTimeline";
 import type { Stop } from "@/components/ItineraryStopCard";
@@ -511,6 +513,7 @@ export default function PremiumPlannerPage() {
     const perDay = Math.ceil(itinerary.length / days);
 
     return (
+      <DndProvider backend={HTML5Backend}>
       <main ref={pdfRef} className="min-h-screen bg-blue-50 pb-16">
         {/* HERO */}
         <div className="bg-gradient-to-r from-red-600 to-red-800 text-white py-16">
@@ -558,19 +561,30 @@ export default function PremiumPlannerPage() {
 
           {/* timeline por día */}
           {Array.from({ length: days }).map((_, d) => {
-            const dayStops = itinerary.slice(d * perDay, (d + 1) * perDay);
+            const start = d * perDay;
+            const dayStops = itinerary.slice(start, start + perDay);
             return (
               <section
                 key={d}
                 className="bg-white p-8 rounded-3xl shadow-2xl space-y-6"
               >
                 <h3 className="text-2xl font-semibold">Día {d + 1}</h3>
-                <ItineraryTimeline stops={dayStops} />
+                <ItineraryTimeline
+                  stops={dayStops}
+                  onReorder={(newDay) =>
+                    setItinerary((prev) => {
+                      const copy = [...prev];
+                      copy.splice(start, newDay.length, ...newDay);
+                      return copy;
+                    })
+                  }
+                />
               </section>
             );
           })}
         </div>
       </main>
+      </DndProvider>
     );
   }
 


### PR DESCRIPTION
## Summary
- make itinerary timeline stops sortable via react-dnd
- update planner page to sync drag changes to itinerary and map

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849bd2452ec832b9c588362c767805e