### PR TITLE
Fix itinerary timeline day grouping

### DIFF
--- a/src/app/planner/page.tsx
+++ b/src/app/planner/page.tsx
@@ -609,9 +609,8 @@ export default function PremiumPlannerPage() {
           {/* timeline por día */}
           {Array.from({ length: days }).map((_, d) => {
 
-            const start = d * perDay;
-            const dayStops = itinerary.slice(start, start + perDay);
             const dayStops = itinerary.filter((s) => s.day === d + 1);
+            const start = itinerary.findIndex((s) => s.day === d + 1);
 
             return (
               <section
@@ -623,6 +622,7 @@ export default function PremiumPlannerPage() {
                   stops={dayStops}
                   onReorder={(newDay) =>
                     setItinerary((prev) => {
+                      if (!prev) return prev;
                       const copy = [...prev];
                       copy.splice(start, newDay.length, ...newDay);
                       return copy;


### PR DESCRIPTION
## Summary
- avoid duplicate variable declaration for day stops
- filter by day when building each daily timeline and compute start index
- prevent null itinerary issues when reordering stops

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch fonts from Google)*

------
https://chatgpt.com/codex/tasks/task_e_6849e5732410832b94ae1585e33485d2