### PR TITLE
Load profile questions dynamically

### DIFF
--- a/src/app/planner/page.tsx
+++ b/src/app/planner/page.tsx
@@ -11,7 +11,6 @@ import {
   Clock,
   Calendar,
   Share2,
-  FileText,
   Download,
 } from "lucide-react";
 import { generateUniqueLink } from "utils/linkGenerator";
@@ -35,9 +34,6 @@ type ApiStop = {
 };
 
 type ApiResponse = { itinerary: ApiStop[]; error?: string };
-type SharedData = { itinerary: Stop[]; days: number } | null;
-
-type WritableStyle = Record<string, string>;
 
 declare global {
   interface Window {
@@ -48,29 +44,13 @@ declare global {
   }
 }
 
-const promptCards = [
-  "Vivir el Carnaval de Barranquilla",
-  "Ruta de museos y galerías",
-  "Tour gastronómico costeño",
-  "Playas paradisíacas y deportes acuáticos",
-  "Pueblos patrimoniales y cultura indígena",
-  "Senderismo y avistamiento de fauna",
-  "Fotografía de paisajes y atardeceres",
-  "Ruta de la música y la vida nocturna",
-  "Arquitectura colonial e historia",
-  "Experiencia de voluntariado ecológico",
-];
 
 /* ═════════════════ COMPONENTE ═════════════════ */
 
 export default function PremiumPlannerPage() {
-  /* wizard answers */
-  const [answers, setAnswers] = useState<{
-    days?: number;
-    motivo?: string;
-    otros?: boolean;
-    email?: string;
-  }>({});
+  /* preguntas y respuestas */
+  const [questions, setQuestions] = useState<string[]>([]);
+  const [answers, setAnswers] = useState<string[]>([]);
   const [qIndex, setQIndex] = useState(0);
 
   /* ubicación */
@@ -144,102 +124,45 @@ export default function PremiumPlannerPage() {
     };
   }, [useLocation]);
 
+  /* cargar preguntas al iniciar */
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/itinerary/profile', { method: 'POST' });
+        const data = await res.json();
+        if (Array.isArray(data.questions)) {
+          setQuestions(data.questions);
+          setAnswers(Array(data.questions.length).fill(''));
+        }
+      } catch (err) {
+        console.error('Error cargando preguntas:', err);
+      }
+    };
+    load();
+  }, []);
+
   /* pasos wizard */
-  const steps = [
-    {
-      label: "¿Cuántos días planeas visitar?",
-      valid: answers.days !== undefined,
-      element: (
-        <select
-          value={answers.days ?? ""}
-          onChange={(e) =>
-            setAnswers((a) => ({ ...a, days: Number(e.target.value) }))
-          }
-          className="w-full border-b-2 border-gray-300 pb-2 focus:border-red-500 outline-none text-lg"
-        >
-          <option value="" disabled>
-            Selecciona días
-          </option>
-          {Array.from({ length: 14 }, (_, i) => i + 1).map((d) => (
-            <option key={d} value={d}>
-              {d} día{d > 1 ? "s" : ""}
-            </option>
-          ))}
-        </select>
-      ),
-    },
-    {
-      label: "Cuéntanos qué te gustaría hacer o aprender",
-      helper: "Elige un prompt o escribe tu propio motivo",
-      valid: !!answers.motivo,
-      element: (
-        <>
-          <input
-            value={answers.motivo ?? ""}
-            onChange={(e) =>
-              setAnswers((a) => ({ ...a, motivo: e.target.value }))
-            }
-            placeholder="Ej. Tour gastronómico costeño…"
-            className="w-full border-b-2 border-gray-300 pb-2 focus:border-red-500 outline-none text-lg"
-          />
-          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-6">
-            {promptCards.map((p) => (
-              <button
-                key={p}
-                onClick={() => setAnswers((a) => ({ ...a, motivo: p }))}
-                className={`p-4 rounded-2xl border transition text-left shadow-sm hover:shadow-lg ${
-                  answers.motivo === p
-                    ? "bg-red-600 text-white border-red-600"
-                    : "bg-white text-gray-700 hover:bg-red-50"
-                }`}
-              >
-                {p}
-              </button>
-            ))}
-          </div>
-        </>
-      ),
-    },
-    {
-      label: "¿Estás dispuesto a visitar otros municipios?",
-      valid: answers.otros !== undefined,
-      element: (
-        <div className="flex gap-4">
-          {["Sí", "No"].map((opt, i) => (
-            <button
-              key={opt}
-              onClick={() => setAnswers((a) => ({ ...a, otros: i === 0 }))}
-              className={`flex-1 py-3 rounded-full text-lg font-medium transition ${
-                answers.otros === (i === 0)
-                  ? "bg-red-600 text-white shadow-lg"
-                  : "bg-gray-200 text-gray-700 hover:bg-gray-300"
-              }`}
-            >
-              {opt}
-            </button>
-          ))}
-        </div>
-      ),
-    },
-    {
-      label: "Ingresa tu correo electrónico",
-      helper: "Te enviaremos el plan generado a este correo",
-      valid: /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(answers.email || ""),
-      element: (
-        <input
-          type="email"
-          value={answers.email ?? ""}
-          onChange={(e) => setAnswers((a) => ({ ...a, email: e.target.value }))}
-          placeholder="Ej. tuemail@ejemplo.com"
-          className="w-full border-b-2 border-gray-300 pb-2 focus:border-red-500 outline-none text-lg"
-        />
-      ),
-    },
-  ];
+  const steps = questions.map((q, i) => ({
+    label: q,
+    valid: !!answers[i],
+    element: (
+      <input
+        value={answers[i] ?? ""}
+        onChange={(e) => {
+          const copy = [...answers];
+          copy[i] = e.target.value;
+          setAnswers(copy);
+        }}
+        className="w-full border-b-2 border-gray-300 pb-2 focus:border-red-500 outline-none text-lg"
+      />
+    ),
+  }));
 
   const next = () => qIndex < steps.length - 1 && setQIndex((i) => i + 1);
   const prev = () => qIndex > 0 && setQIndex((i) => i - 1);
-  const progress = ((qIndex + 1) / steps.length) * 100;
+  const progress = steps.length
+    ? ((qIndex + 1) / steps.length) * 100
+    : 0;
 
   /* API & itinerario */
   const [itinerary, setItinerary] = useState<Stop[] | null>(null);
@@ -264,23 +187,20 @@ export default function PremiumPlannerPage() {
   const generateItinerary = async () => {
     if (!steps.every((s) => s.valid)) return;
     setView("loading");
-    const profile = {
-      Días: String(answers.days),
-      Motivo: answers.motivo,
-      "Otros municipios": answers.otros ? "Sí" : "No",
-      Email: answers.email,
-    };
+    const payload = { questions, answers };
     
     try {
       const res = await fetch("/api/itinerary/generate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ 
-          profile, 
-          location: location ? { 
-            lat: location.lat, 
-            lng: location.lng 
-          } : null
+        body: JSON.stringify({
+          qa: payload,
+          location: location
+            ? {
+                lat: location.lat,
+                lng: location.lng,
+              }
+            : null,
         }),
       });
       
@@ -347,7 +267,10 @@ export default function PremiumPlannerPage() {
   const handleShare = async () => {
     if (!itinerary?.length) return alert("Itinerario vacío");
     try {
-      const url = await generateUniqueLink(itinerary, answers.days ?? 1);
+      const url = await generateUniqueLink(
+        itinerary,
+        parseInt(answers[1] || '1', 10) || 1
+      );
       await navigator.clipboard.writeText(url);
       alert("Link copiado ✅");
     } catch (e) {
@@ -511,7 +434,7 @@ export default function PremiumPlannerPage() {
     const totalH = Math.round(
       itinerary.reduce((s, t) => s + t.durationMinutes, 0) / 60
     );
-    const days = answers.days ?? 1;
+    const days = parseInt(answers[1] || '1', 10) || 1;
     const perDay = Math.ceil(itinerary.length / days);
 
     return (

--- a/src/components/ItineraryTimeline.tsx
+++ b/src/components/ItineraryTimeline.tsx
@@ -18,8 +18,6 @@ import {
   Landmark,
   Navigation,
   ExternalLink,
-  Info,
-  Star,
 } from "lucide-react";
 
 interface Props {
@@ -64,7 +62,7 @@ export default function ItineraryTimeline({ stops }: Props) {
   /* ▸ 1. COMPLETAR HORARIOS FALTANTES */
   const filledStops = useMemo(() => {
     let current = 9 * 60; // 09:00 default
-    return stops.map((s, idx) => {
+    return stops.map((s) => {
       let start = s.startTime && /^\d{1,2}:\d{2}$/.test(s.startTime) ? s.startTime : "";
       if (start) current = toMin(start); // usa la hora provista
       else start = toHHMM(current); // calcula

--- a/src/pages/api/generate-pdf.ts
+++ b/src/pages/api/generate-pdf.ts
@@ -6,6 +6,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   try {
     // Para producción (Vercel)
     if (process.env.NODE_ENV === 'production') {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const chromium = require('chrome-aws-lambda');
       browser = await chromium.puppeteer.launch({
         args: chromium.args,
@@ -15,6 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     } 
     // Para desarrollo local
     else {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const puppeteer = require('puppeteer');
       browser = await puppeteer.launch();
     }

--- a/src/pages/api/itinerary/generate.ts
+++ b/src/pages/api/itinerary/generate.ts
@@ -277,6 +277,7 @@ function validateAIResponse(aiJSON: string, allStops: ItineraryStop[]) {
     const invalid: string[] = [];
     const seen = new Set<string>();
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     aiItinerary.forEach((item: any) => {
       if (!item?.id || seen.has(item.id)) return;
       seen.add(item.id);
@@ -331,7 +332,7 @@ function calculateTimings(itinerary: ItineraryStop[]) {
 async function savePlanningRequest(
   db: FirebaseFirestore.Firestore,
   profile: Record<string, string>,
-  location: any,
+  location: { lat: number; lng: number } | null,
   itinerary: ItineraryStop[]
 ) {
   try {


### PR DESCRIPTION
## Summary
- fetch `/api/itinerary/profile` on page load
- display returned questions in the trip planner wizard
- send collected answers when requesting an itinerary
- lint cleanups for timeline, pdf API and itinerary API

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849ee60e268832b893a58b3d39fdb04