### PR TITLE
Enable offline itinerary caching

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,37 @@
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
+
+if (self.workbox) {
+  self.workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || []);
+
+  self.workbox.routing.registerRoute(
+    ({request}) => request.mode === 'navigate',
+    new self.workbox.strategies.NetworkFirst({ cacheName: 'pages' })
+  );
+
+  self.workbox.routing.registerRoute(
+    ({request}) => ['style','script','worker'].includes(request.destination),
+    new self.workbox.strategies.StaleWhileRevalidate({ cacheName: 'assets' })
+  );
+}
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'CACHE_ITINERARY') {
+    const data = event.data.payload;
+    event.waitUntil(
+      caches.open('itinerary-cache').then(cache => {
+        const response = new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+        return cache.put('/offline-itinerary', response);
+      })
+    );
+  }
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.url.endsWith('/offline-itinerary')) {
+    event.respondWith(
+      caches.open('itinerary-cache').then(cache => cache.match('/offline-itinerary'))
+    );
+  }
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@
 import "./globals.css";
 import { Poppins, Merriweather_Sans } from "next/font/google";
 import { ReactNode } from "react";
+import ServiceWorkerRegister from "@/components/ServiceWorkerRegister";
 import type { Metadata } from "next";
 
 const poppins = Poppins({
@@ -93,7 +94,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           }}
         />
       </head>
-      <body className="font-sans">{children}</body>
+      <body className="font-sans">
+        <ServiceWorkerRegister />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/components/ServiceWorkerRegister.tsx
+++ b/src/components/ServiceWorkerRegister.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { useEffect } from "react";
+
+export default function ServiceWorkerRegister() {
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker
+        .register("/sw.js")
+        .catch((err) => console.error("SW registration failed", err));
+    }
+  }, []);
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a Workbox-based service worker for caching pages, assets and itineraries
- register the service worker in the main layout
- allow saving generated itineraries for offline use
- load cached itinerary data when offline

## Testing
- `npm run lint` *(fails: FileText is defined but never used, etc.)*
- `npm run build` *(fails: Failed to fetch font `Poppins` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6849faf42dd0832b9bc5a18808f7de3c