### PR TITLE
Add directions overlay

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,7 @@
 /* src/app/globals.css */
 
 @import 'mapbox-gl/dist/mapbox-gl.css';
+@import '@mapbox/mapbox-gl-directions/dist/mapbox-gl-directions.css';
 @import "tailwindcss";
 @import "tw-animate-css";
 


### PR DESCRIPTION
## Summary
- import MapboxDirections and initialize in ItineraryMap
- request directions between itinerary stops and place travel time markers
- include Mapbox Directions CSS

## Testing
- `npm run lint` *(fails: several existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_6849faf4e990832b972bd7e2706d30bc