### PR TITLE
Add cross-day drag and drop for itinerary

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,21 +1,23 @@
 // src/app/layout.tsx
-/* eslint-disable @next/next/no-page-custom-font */
 
 import "./globals.css";
+import { Poppins, Merriweather_Sans } from "next/font/google";
 import { ReactNode } from "react";
-    <html lang="es">
-        {/* Google Fonts */}
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Merriweather+Sans:wght@400;600;700&display=swap"
-          rel="stylesheet"
-        />
+import ServiceWorkerRegister from "@/components/ServiceWorkerRegister";
+import type { Metadata } from "next";
 
+const poppins = Poppins({
+  subsets: ["latin"],
+  weight: ["400", "600", "700"],
+  variable: "--font-poppins",
+});
+const merriweatherSans = Merriweather_Sans({
+  subsets: ["latin"],
+  weight: ["400", "600", "700"],
+  variable: "--font-merriweather-sans",
+});
+
+export const metadata: Metadata = {
   title: "VisitAtlántico · Explora el paraíso costero",
   description: "Descubre playas, cultura y aventuras en Atlántico, Colombia.",
   robots: "index, follow",


### PR DESCRIPTION
## Summary
- support moving itinerary items across days
- expose global move handler and save actions in planner page
- ensure itinerary timeline uses global offsets for drag indexes
- restore layout.tsx

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a52ac96c0832b8e9d941381fac2df