### PR TITLE
Enable drag & drop editing in itinerary timeline

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,21 +1,23 @@
 // src/app/layout.tsx
-/* eslint-disable @next/next/no-page-custom-font */
 
 import "./globals.css";
+import { Poppins, Merriweather_Sans } from "next/font/google";
 import { ReactNode } from "react";
-    <html lang="es">
-        {/* Google Fonts */}
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Merriweather+Sans:wght@400;600;700&display=swap"
-          rel="stylesheet"
-        />
+import ServiceWorkerRegister from "@/components/ServiceWorkerRegister";
+import type { Metadata } from "next";
 
+const poppins = Poppins({
+  subsets: ["latin"],
+  weight: ["400", "600", "700"],
+  variable: "--font-poppins",
+});
+const merriweatherSans = Merriweather_Sans({
+  subsets: ["latin"],
+  weight: ["400", "600", "700"],
+  variable: "--font-merriweather-sans",
+});
+
+export const metadata: Metadata = {
   title: "VisitAtlántico · Explora el paraíso costero",
   description: "Descubre playas, cultura y aventuras en Atlántico, Colombia.",
   robots: "index, follow",

--- a/src/app/planner/page.tsx
+++ b/src/app/planner/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import ItineraryMap from "@/components/ItineraryMap";
@@ -12,6 +12,7 @@ import {
   MapPin,
   Clock,
   Calendar,
+  FileText,
   Share2,
   Download,
 } from "lucide-react";
@@ -171,6 +172,16 @@ export default function PremiumPlannerPage() {
   const [view, setView] =
     useState<"questions" | "loading" | "itinerary">("questions");
   const pdfRef = useRef<HTMLDivElement>(null);
+
+  const handleReorder = useCallback((from: number, to: number) => {
+    setItinerary((curr) => {
+      if (!curr) return curr;
+      const updated = [...curr];
+      const [item] = updated.splice(from, 1);
+      updated.splice(to, 0, item);
+      return updated;
+    });
+  }, []);
 
   useEffect(() => {
     if (navigator.onLine) return;
@@ -420,9 +431,6 @@ export default function PremiumPlannerPage() {
     }
   };
 
-    }
-  };
-
   /* ═════ vista loading ════ */
   if (view === "loading") {
     const frases = [
@@ -528,6 +536,8 @@ export default function PremiumPlannerPage() {
                 <ItineraryTimeline
                   stops={dayStops}
                   editable
+                  offset={d * perDay}
+                  onMove={handleReorder}
                   onChange={(newStops) => {
                     const updated = [...itinerary];
                     updated.splice(d * perDay, newStops.length, ...newStops);


### PR DESCRIPTION
## Summary
- restore complete layout.tsx
- add global drag and drop handling to `ItineraryTimeline`
- update planner page to use new props and reorder stops across days

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684abb04765c832ba684f0e408b577ee